### PR TITLE
partition.h: make partitions 1M byte alignment

### DIFF
--- a/hisi_partition.h
+++ b/hisi_partition.h
@@ -52,4 +52,5 @@ enum {
 #define PART_XLOADER_A                 "xloader_a"
 #define PART_XLOADER_B                 "xloader_b"
 #define PART_FIP                       "fip"
+#define PART_RESERVED                  "reserved"
 #endif

--- a/partition.h
+++ b/partition.h
@@ -34,20 +34,20 @@ static const struct partition partition_table_ufs[] =
   {PART_PTABLE,           0,         1024,            UFS_PART_2},/* ptable          512K */
   {PART_FRP,              1024,      7*1024,          UFS_PART_2},/* frp             512K   p1*/
   {PART_PTABLE_LU3,       0,         1024,            UFS_PART_3},/* ptable_lu3    1M    sdd  */
-  {PART_XLOADER_RESERVED1,1024,       512,            UFS_PART_3},/* vrl             512K   sdd1*/
-  {PART_XLOADER_RESERVED2,1536,      512,             UFS_PART_3},/* vrl backup      512K   sdd2*/
-  {PART_FASTBOOT,         2*1024,      12*1024,       UFS_PART_3},/* fastboot      12M   sdd3 */
-  {PART_NVME,             14*1024,   6*1024,          UFS_PART_3},/* nvme          6M    sdd4 */
+  {PART_XLOADER_RESERVED1,1024,      1024,            UFS_PART_3},/* vrl           1M    sdd1 */
+  {PART_FASTBOOT,         2*1024,    12*1024,         UFS_PART_3},/* fastboot      12M   sdd2 */
+  {PART_NVME,             14*1024,   6*1024,          UFS_PART_3},/* nvme          6M    sdd3 */
   /* Items above shall not be changed, unless you can update xloader simualtaneously. */
-  {PART_CACHE,            20*1024,   256*1024,        UFS_PART_3},/* cache         256M  sdd5 */
-  {PART_FW_LPM3,          276*1024,  1024,            UFS_PART_3},/* mcuimage      1M    sdd6 */
-  {PART_BOOT,             277*1024,  64*1024,         UFS_PART_3},/* boot          64M   sdd7 */
-  {PART_DTS,              341*1024,  16*1024,         UFS_PART_3},/* dtimage       16M   sdd8 */
-  {PART_TRUSTFIRMWARE,    357*1024,  2*1024,          UFS_PART_3},/* trustfirmware 2M    sdd9 */
-  {PART_SYSTEM,           359*1024,  4688*1024,       UFS_PART_3},/* system        4688M sdd10 */
-  {PART_VENDOR,           5047*1024, 784*1024,        UFS_PART_3},/* vendor        784M  sdd11 */
-  {PART_FIP,              5831*1024, 12*1024,         UFS_PART_3},/* fip        12M  sdd12 */
-  {PART_USERDATA,         5843*1024, (4UL)*1024*1024, UFS_PART_3},/* userdata      4G    sdd13 */
+  {PART_FIP,              20*1024,   12*1024,         UFS_PART_3},/* fip           12M   sdd4 */
+  {PART_CACHE,            32*1024,   256*1024,        UFS_PART_3},/* cache         256M  sdd5 */
+  {PART_FW_LPM3,          288*1024,  1024,            UFS_PART_3},/* mcuimage      1M    sdd6 */
+  {PART_BOOT,             289*1024,  64*1024,         UFS_PART_3},/* boot          64M   sdd7 */
+  {PART_DTS,              353*1024,  16*1024,         UFS_PART_3},/* dtimage       16M   sdd8 */
+  {PART_TRUSTFIRMWARE,    369*1024,  2*1024,          UFS_PART_3},/* trustfirmware 2M    sdd9 */
+  {PART_SYSTEM,           371*1024,  4688*1024,       UFS_PART_3},/* system        4688M sdd10 */
+  {PART_VENDOR,           5059*1024, 784*1024,        UFS_PART_3},/* vendor        784M  sdd11 */
+  {PART_RESERVED,         5843*1024, 1024,            UFS_PART_3},/* reserved      1M    sdd12 */
+  {PART_USERDATA,         5844*1024, (4UL)*1024*1024, UFS_PART_3},/* userdata      4G    sdd13 */
   {"0", 0, 0, 0},
 };
 


### PR DESCRIPTION
1. To make partitions 1M byte alignment, PART_XLOADER_RESERVED1 and
    PART_XLOADER_RESERVED2 are merged into one partition, and size is
    1MB.
2. Moved PART_FIP from sdd12 to sdd5, starting at 20M offset. This is
    at request of Arm Trusted Firmware design.
3. Add an reserved partition as sdd12, so userdata partition no. is still
    sdd13, unchanged.

Signed-off-by: Guodong Xu <guodong.xu@linaro.org>